### PR TITLE
fix: drop redundant hooks reference from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,5 @@
   "name": "cc-websearch",
   "displayName": "WebSearch",
   "version": "1.2.4",
-  "description": "DDG-powered WebSearch and WebFetch replacement for Claude Code",
-  "hooks": "./hooks/hooks.json"
+  "description": "DDG-powered WebSearch and WebFetch replacement for Claude Code"
 }


### PR DESCRIPTION
## Summary

Removes the `"hooks": "./hooks/hooks.json"` field from `.claude-plugin/plugin.json`. The standard hooks file at `.claude-plugin/hooks/hooks.json` is loaded automatically by Claude Code, so the manifest reference is redundant - and the path it points to (`./hooks/hooks.json`, relative to the plugin root) doesn't actually exist.

## Symptom

When installing the plugin and running `/doctor`, Claude Code reports a load error:

```
cc-websearch@local-plugins [cc-websearch]: Path not found:
.../1.2.4/hooks/hooks.json (hooks)
```

If you symlink `<plugin_root>/hooks` to `.claude-plugin/hooks` to "fix" the path, the error becomes:

```
Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json
resolves to already-loaded file .../.claude-plugin/hooks/hooks.json.
The standard hooks/hooks.json is loaded automatically, so manifest.hooks
should only reference additional hook files.
```

The error message itself states the resolution: the standard location is auto-loaded, and `manifest.hooks` is only for *additional* hook files beyond that.

## Fix

Drop the line from `plugin.json`. The auto-loader continues to pick up the existing `.claude-plugin/hooks/hooks.json` so the WebSearch/WebFetch deny hooks still fire - just without the duplicate-load error.

## Test plan

- [x] Verified `/doctor` reports no plugin errors after the change (tested locally by editing the cached plugin.json with this same diff).
- [ ] Maintainer to verify on a fresh install that hooks still fire (built-in `WebSearch`/`WebFetch` calls are denied with the existing reason strings).