### PR TITLE
Docs/refresh project docs

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -36,3 +36,34 @@
 - Four low-severity code debt items resolved: withTimeout ETIMEDOUT message, readStdin isTTY guard, normalizeUrl scheme validation, jsdom/@types/jsdom version alignment
 
 ---
+
+## 1.1 Plugin Distribution (Shipped: 2026-05-22)
+
+**Phases completed:** 1 phase (Phase 9), 1 plan
+
+**Key accomplishments:**
+
+- esbuild bundles relocated from the repository root to `skills/websearch/scripts/websearch.cjs` and `skills/webfetch/scripts/webfetch.cjs`, so each skill ships next to the script it invokes
+- SKILL.md command paths switched to `${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/<bundle>.cjs`
+- Path-dependent tests and README examples updated for the new locations
+
+**Known gap at close:** DIST-05 ("old `scripts/` root directory removed") was marked complete but was not done -- `scripts/websearch.cjs` and `scripts/webfetch.cjs` remain tracked in git while nothing builds them.
+
+---
+
+## 1.2 Replace Built-in WebSearch/WebFetch (Shipped: 2026-05-24, released v1.2.4 on 2026-05-25)
+
+**Phases completed:** 3 phases (10-12), 5 plans
+
+**Key accomplishments:**
+
+- PreToolUse deny hooks that intercept the built-in WebSearch and WebFetch tools and redirect Claude to `cc-websearch:websearch` / `cc-websearch:webfetch`. Two separate matchers, each a fixed inline `echo` -- no shell script, no `jq`, and no reading of the tool input
+- Denial reason wording and SKILL.md descriptions tuned for redirect reliability, with `test/e2e/redirect-reliability.e2e.ts` measuring it across diverse prompt patterns
+- Output compatibility proven empirically by `test/e2e/output-compatibility.e2e.ts` (8 tests, 4 search + 4 fetch): WebSearch XML and WebFetch markdown are consumable by Claude after a denial
+- 100KB content truncation in `src/lib/content.ts` to match built-in WebFetch behavior
+- Works on every provider, since the hook does not depend on the built-in tool being present
+
+**Post-milestone correction:** the hook file was first created at `.claude-plugin/hooks/hooks.json` and referenced from `plugin.json`. That combination made Claude Code load the same file twice and fail with "Duplicate hooks file detected". Commit `f99c9d2` moved it to `hooks/hooks.json` at the repository root and dropped the manifest reference, relying on auto-discovery.
+
+---
+

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -8,15 +8,13 @@ A Claude Code plugin providing two skills that replace the built-in WebSearch an
 
 Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same interface, same output format, no behavior changes for the user.
 
-## Current Milestone: v1.2 Replace Built-in WebSearch/WebFetch
+## Current Milestone: none active
 
-**Goal:** Make the cc-websearch plugin replace Claude Code's built-in WebSearch and WebFetch tools for ALL providers — the plugin is always used regardless of whether the provider is Anthropic or not.
+**Last shipped:** v1.2 Replace Built-in WebSearch/WebFetch — phases 10-12 complete 2026-05-24, released as v1.2.4 on 2026-05-25.
 
-**Target features:**
-- Investigate how Claude Code routes built-in tools vs plugin skills
-- Find mechanism to override/disable built-in WebSearch and WebFetch
-- Implement solution so plugin skills are always used instead of built-in tools
-- Works identically for all providers (Anthropic, OpenAI, self-hosted, etc.)
+The plugin now ships `hooks/hooks.json`, whose PreToolUse hooks deny the built-in WebSearch and WebFetch tools and redirect Claude to `cc-websearch:websearch` / `cc-websearch:webfetch`. This works on every provider, since the hook does not depend on the built-in tool existing.
+
+Since the release the repository has been in maintenance: Dependabot bumps, a CI move to Node 24 (jsdom 30 dropped Node 20), and Prettier/typing fixes to `build.ts`.
 
 ## Requirements
 
@@ -37,12 +35,11 @@ Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same inte
 
 ### Active
 
-- [ ] **DIST-01**: Bundles output to `skills/<name>/scripts/` with esbuild
-- [ ] **DIST-02**: SKILL.md references use `${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/`
-- [ ] **DIST-03**: Old `scripts/` root directory removed
-- [ ] **DIST-04**: Path-dependent tests and CI updated
+- [ ] **DIST-03**: Old `scripts/` root directory removed — still open. `scripts/websearch.cjs` and `scripts/webfetch.cjs` are still tracked in git even though `build.ts` writes only to `skills/*/scripts/`. They are stale orphans, hidden by `.prettierignore` and the ESLint ignore list. REQUIREMENTS.md marks the equivalent DIST-05 as done; that is wrong.
 - [ ] Optional caching — enabled via config, cache directory configurable, no cache when not configured
-- [ ] CLI flags for testing outside Claude Code (`--query`, `--url`, `--prompt`, `--allowed-domains`, `--blocked-domains`)
+- [ ] Drop unused dependencies — nothing imports `commander` or `duck-duck-scrape`; neither reaches the bundles
+
+Retired from Active: DIST-01, DIST-02 and DIST-04 shipped with v1.1. The CLI-flag item (`--query`, `--url`, ...) was never built and is not planned — both entry points read JSON from stdin only. `commander` was added for it and left behind. Note that `src/lib/input.ts` still tells the user to "use --query / --url flags" in its no-input error; that message is wrong and should be fixed or the flags implemented.
 
 ### Out of Scope
 
@@ -54,8 +51,8 @@ Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same inte
 
 ## Context
 
-- Shipped v1.0 with ~3,000 LOC TypeScript, 142 tests, 14 test files
-- Tech stack: TypeScript, Node.js 20+, DuckDuckGo Lite HTML scraping via fetch + cheerio, Readability + Turndown for content extraction
+- ~3,400 LOC TypeScript (692 in `src/`, 2,673 in `test/`, 90 in `build.ts`), 143 tests across 14 test files
+- Tech stack: TypeScript, Node `^22.22.2 || ^24.15.0 || >=26.0.0` (raised by jsdom 30; CI runs Node 24), DuckDuckGo Lite HTML scraping via fetch + cheerio, Readability + Turndown for content extraction
 - DuckDuckGo Lite endpoint (`https://lite.duckduckgo.com/lite/`) provides stable search results without API keys — no rate limiting from the Lite endpoint
 - E2E tests validate real DDG search and WebFetch behavior against live network
 - GitHub Actions CI runs lint, typecheck, test coverage, and build on every PR
@@ -64,7 +61,7 @@ Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same inte
 
 ## Constraints
 
-- **Runtime**: TypeScript/Node — scripts run via `node`
+- **Runtime**: TypeScript/Node — scripts run via `node`; `engines` requires `^22.22.2 || ^24.15.0 || >=26.0.0`
 - **Distribution**: Standard Claude Code plugin — installable via plugin command
 - **Output format**: Must match Claude Code's WebSearch and WebFetch output byte-for-byte
 - **DDG API**: DuckDuckGo Lite HTML scraping (`https://lite.duckduckgo.com/lite/`)
@@ -75,13 +72,15 @@ Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same inte
 | Decision                            | Rationale                                                                              | Outcome       |
 | ----------------------------------- | -------------------------------------------------------------------------------------- | ------------- |
 | TypeScript/Node                     | Matches Claude Code plugin ecosystem, skill scripts run via `node`                     | ✓ Good        |
-| Perplexity Chat Completions         | More flexible than Ask API, structured results with citations                          | ⚠️ Revisit    |
+| Perplexity Chat Completions         | More flexible than Ask API, structured results with citations                          | ✗ Removed (Phase 5) |
 | DDG Lite HTML scraping              | No API key required, widely used pattern, reliable fallback                            | ✓ Good        |
 | Exponential + jitter retry          | Standard best practice for rate-limited APIs, prevents thundering herd                 | ✓ Good        |
 | Hybrid CLI input (stdin JSON)       | JSON stdin matching tool schema for Claude Code use                                    | ✓ Good        |
 | Markdown stdout + stderr errors     | Matches Claude Code output format directly, clean separation of results vs diagnostics | ✓ Good        |
 | Readability + Turndown for WebFetch | Standard HTML content extraction + markdown conversion pipeline                        | ✓ Good        |
 | Optional configurable caching       | Saves API credits on repeat queries, disabled by default to keep simple                | — Deferred    |
+| PreToolUse deny hooks (v1.2)        | Only viable interception point: skills are namespaced and cannot shadow built-in tool names | ✓ Good        |
+| Hooks in `hooks/hooks.json`, not the manifest | Standard path is auto-discovered; a `hooks` field in plugin.json duplicates it and errors | ✓ Good        |
 | fetch + cheerio (DDG Lite)          | Replaced duck-duck-scrape (Phase 8), stable Lite endpoint, no rate limiting           | ✓ Good        |
 | DDG-only architecture               | Perplexity pricing no longer viable, zero API keys, simpler maintenance                | ✓ Good        |
 
@@ -106,4 +105,4 @@ This document evolves at phase transitions and milestone boundaries.
 
 ---
 
-*Last updated: 2026-05-22 after v1.2 milestone start*
+*Last updated: 2026-08-29 — reconciled with the shipped code after the v1.2 release*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -11,19 +11,19 @@
 - [x] **DIST-02**: SKILL.md command paths use `${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/<bundle>.cjs`
 - [x] **DIST-03**: README examples and installation instructions reflect new script locations
 - [x] **DIST-04**: Path-dependent tests updated for new bundle locations
-- [x] **DIST-05**: Old `scripts/` root directory removed after bundles relocated
+- [ ] **DIST-05**: Old `scripts/` root directory removed after bundles relocated — NOT done. `scripts/websearch.cjs` and `scripts/webfetch.cjs` are still tracked in git; `build.ts` writes only to `skills/*/scripts/`, so they are stale orphans. Was marked complete in error.
 - [x] **DIST-06**: `npm run build` and `npm run check` pass clean
 
-## v1.2 Requirements
+## v1.2 Requirements (Shipped)
 
-Requirements for replacing built-in WebSearch and WebFetch with plugin skills via PreToolUse hooks.
+Requirements for replacing built-in WebSearch and WebFetch with plugin skills via PreToolUse hooks. All 12 complete; released as v1.2.4 on 2026-05-25.
 
 ### Hook Infrastructure
 
-- [ ] **HOOK-01**: Plugin registers PreToolUse hook that denies built-in WebSearch tool calls with a redirect reason instructing Claude to use the plugin skill
-- [ ] **HOOK-02**: Plugin registers PreToolUse hook that denies built-in WebFetch tool calls with a redirect reason instructing Claude to use the plugin skill
-- [ ] **HOOK-03**: Hook configuration is inline in plugin.json (no external shell scripts or jq dependency)
-- [ ] **HOOK-04**: Hook matcher uses exact case-sensitive tool names (`WebSearch|WebFetch`)
+- [x] **HOOK-01**: Plugin registers PreToolUse hook that denies built-in WebSearch tool calls with a redirect reason instructing Claude to use the plugin skill
+- [x] **HOOK-02**: Plugin registers PreToolUse hook that denies built-in WebFetch tool calls with a redirect reason instructing Claude to use the plugin skill
+- [x] **HOOK-03**: Hook configuration is inline in `hooks/hooks.json` (no external shell scripts or jq dependency). As built the file lives at the plugin root and is auto-discovered — it is deliberately NOT referenced from plugin.json, which would duplicate it and fail to load.
+- [x] **HOOK-04**: Hook matchers use exact case-sensitive tool names. As built these are two separate matchers, `WebSearch` and `WebFetch`, rather than one `WebSearch|WebFetch` alternation, so each deny reason can name its own skill.
 
 ### Redirect Reliability
 
@@ -68,10 +68,10 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| HOOK-01 | Phase 10 | Pending |
-| HOOK-02 | Phase 10 | Pending |
-| HOOK-03 | Phase 10 | Pending |
-| HOOK-04 | Phase 10 | Pending |
+| HOOK-01 | Phase 10 | Complete |
+| HOOK-02 | Phase 10 | Complete |
+| HOOK-03 | Phase 10 | Complete |
+| HOOK-04 | Phase 10 | Complete |
 | RDIR-01 | Phase 11 | Complete |
 | RDIR-02 | Phase 11 | Complete |
 | RDIR-03 | Phase 11 | Complete |
@@ -85,7 +85,8 @@ Which phases cover which requirements. Updated during roadmap creation.
 - v1.2 requirements: 12 total
 - Mapped to phases: 12
 - Unmapped: 0
+- Complete: 12
 
 ---
 *Requirements defined: 2026-05-22*
-*Last updated: 2026-05-22 after v1.2 roadmap creation*
+*Last updated: 2026-08-29 — v1.2 closed out, HOOK-01..04 marked complete, DIST-05 corrected to open*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Build a Claude Code plugin that replaces the built-in WebSearch and WebFetch tools with DuckDuckGo as the sole search provider. The journey starts with a working plugin skeleton and Perplexity-powered search, adds resilience through DDG fallback and domain filtering, delivers the independent WebFetch content pipeline, adds config file support and configurable logging, transitions to DDG-only with citations, establishes CI and E2E tests, completes documentation, closes tech debt, relocates scripts for plugin distribution, and now intercepts built-in tool calls via PreToolUse hooks to redirect to plugin skills.
+Build a Claude Code plugin that replaces the built-in WebSearch and WebFetch tools with DuckDuckGo as the sole search provider. The journey starts with a working plugin skeleton and Perplexity-powered search, adds resilience through DDG fallback and domain filtering, delivers the independent WebFetch content pipeline, adds config file support and configurable logging, transitions to DDG-only with citations, establishes CI and E2E tests, completes documentation, closes tech debt, relocates scripts for plugin distribution, and finally intercepts built-in tool calls via PreToolUse hooks to redirect to plugin skills. The Perplexity-powered start was removed in Phase 5; DDG has been the sole provider since.
 
 ## Milestones
 
 - ✅ **v1.0 MVP** — Phases 1-8 (shipped 2026-05-22)
 - ✅ **v1.1 Plugin Distribution** — Phase 9 (shipped 2026-05-22)
-- 🚧 **v1.2 Replace Built-in WebSearch/WebFetch** — Phases 10-12 (in progress)
+- ✅ **v1.2 Replace Built-in WebSearch/WebFetch** — Phases 10-12 (shipped 2026-05-24, released v1.2.4 on 2026-05-25)
 
 ## Phases
 
@@ -33,7 +33,7 @@ Build a Claude Code plugin that replaces the built-in WebSearch and WebFetch too
 
 </details>
 
-### 🚧 v1.2 Replace Built-in WebSearch/WebFetch (In Progress)
+### ✅ v1.2 Replace Built-in WebSearch/WebFetch — SHIPPED 2026-05-24
 
 **Milestone Goal:** Plugin automatically intercepts built-in WebSearch and WebFetch tool calls via PreToolUse hooks, denies them, and redirects Claude to use the plugin skills instead. Works on all providers.
 
@@ -52,8 +52,8 @@ Build a Claude Code plugin that replaces the built-in WebSearch and WebFetch too
 
   1. Installing the plugin causes all built-in WebSearch tool calls to be denied with a redirect reason
   2. Installing the plugin causes all built-in WebFetch tool calls to be denied with a redirect reason
-  3. Hook configuration is self-contained in plugin.json with no external shell scripts or jq dependency
-  4. Hook matchers use exact case-sensitive tool names (WebSearch|WebFetch) — lowercase matchers are absent
+  3. Hook configuration is self-contained with no external shell scripts or jq dependency — as built, an inline `echo` in `hooks/hooks.json`, not in plugin.json
+  4. Hook matchers use exact case-sensitive tool names — as built, two separate matchers `WebSearch` and `WebFetch`; lowercase matchers are absent
 
 **Plans**: 1 plan
 
@@ -126,3 +126,9 @@ Phases execute in numeric order: 10 → 11 → 12
 | 10. Hook Infrastructure | v1.2 | 1/1 | Complete   | 2026-05-23 |
 | 11. Redirect Reliability | v1.2 | 2/2 | Complete    | 2026-05-24 |
 | 12. Output & Compatibility | v1.2 | 2/2 | Complete    | 2026-05-24 |
+
+## Status
+
+All 12 phases across v1.0, v1.1 and v1.2 are complete. No milestone is currently active; the repository is in maintenance (dependency bumps and CI upkeep).
+
+*Last updated: 2026-08-29*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,35 +2,35 @@
 gsd_state_version: 1.0
 milestone: v1.2
 milestone_name: Replace Built-in WebSearch/WebFetch
-status: "Phase 12 shipped — PR #10"
-stopped_at: Phase 12 context gathered
-last_updated: "2026-05-24T17:12:34.217Z"
-last_activity: 2026-05-24
+status: "v1.2 complete — released v1.2.4"
+stopped_at: Milestone complete
+last_updated: "2026-08-29T00:00:00.000Z"
+last_activity: 2026-08-29
 progress:
   total_phases: 3
-  completed_phases: 2
+  completed_phases: 3
   total_plans: 5
   completed_plans: 5
-  percent: 67
+  percent: 100
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-05-22)
+See: .planning/PROJECT.md (updated 2026-08-29)
 
 **Core value:** DDG-powered drop-in replacement for Claude Code's WebSearch and WebFetch -- same interface, same output format, works on all providers. Zero API keys required.
-**Current focus:** Milestone complete
+**Current focus:** Maintenance — no milestone active
 
 ## Current Position
 
-Phase: 12
-Plan: Not started
-Status: Phase 12 shipped — PR #10
-Last activity: 2026-05-24
+Phase: 12 (last)
+Plan: All complete
+Status: v1.2 complete — released v1.2.4 on 2026-05-25
+Last activity: 2026-08-29
 
-Progress: [████████░░] 83%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -76,26 +76,35 @@ Recent decisions affecting current work:
 
 ### Pending Todos
 
-None.
+No milestone work is queued. Four housekeeping items are open -- see Blockers/Concerns below.
 
 ### Blockers/Concerns
 
-- Redirect reliability is untested — research confirms mechanism exists but no empirical success rate data. Phase 11 must test across diverse prompt patterns.
-- WebFetch output format needs empirical verification — Agent SDK types show structured JSON but actual conversation-visible output may differ. Phase 12 must test against real Claude Code.
+Both v1.2 concerns are resolved:
+
+- ~~Redirect reliability is untested~~ — closed by Phase 11 (`test/e2e/redirect-reliability.e2e.ts`).
+- ~~WebFetch output format needs empirical verification~~ — closed by Phase 12 (`test/e2e/output-compatibility.e2e.ts`); raw markdown on stdout is correct.
+
+Open items carried forward:
+
+- `scripts/websearch.cjs` and `scripts/webfetch.cjs` are still tracked in git but nothing builds or ships them — DIST-05 was marked done in error.
+- `commander` and `duck-duck-scrape` are declared dependencies that nothing imports.
+- `src/lib/input.ts` tells the user to "use --query / --url flags" on empty input, but no such flags exist.
+- The committed bundles in `skills/*/scripts/` are stale: rebuilding on the current lockfile produces a large diff.
 
 ## Deferred Items
 
-Items acknowledged and carried forward from v1.1 milestone close:
+Items carried forward from the v1.1 milestone close, all since resolved by the repository going public:
 
 | Category | Item | Status | Deferred At |
 |----------|------|--------|-------------|
-| verification | Phase 06 - GitHub Actions PR gate | Deferred (requires push to GitHub) | 2026-05-22 |
-| verification | Phase 06 - Cron workflow and Dependabot | Deferred (requires push to GitHub) | 2026-05-22 |
-| uat | Phase 06 - GitHub Actions PR gate | Deferred (requires push to GitHub) | 2026-05-22 |
-| uat | Phase 06 - Cron/Dependabot | Deferred (requires push to GitHub) | 2026-05-22 |
+| verification | Phase 06 - GitHub Actions PR gate | Resolved — `.github/workflows/ci.yml` gates every PR | 2026-05-22 |
+| verification | Phase 06 - Cron workflow and Dependabot | Resolved — `periodic.yml` runs weekly; Dependabot opens grouped PRs | 2026-05-22 |
+| uat | Phase 06 - GitHub Actions PR gate | Resolved — observed on live PRs | 2026-05-22 |
+| uat | Phase 06 - Cron/Dependabot | Resolved — observed on live PRs | 2026-05-22 |
 
 ## Session Continuity
 
-Last session: 2026-05-24T16:37:21.949Z
-Stopped at: Phase 12 context gathered
-Resume file: .planning/phases/12-output-compatibility/12-CONTEXT.md
+Last session: 2026-08-29
+Stopped at: Milestone complete — nothing in flight
+Resume file: none

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -2,6 +2,7 @@
 
 **Domain:** Claude Code plugin -- tool replacement architecture
 **Researched:** 2026-05-22
+**Updated:** 2026-08-29 -- reconciled with the shipped implementation (see "As-Built" notes)
 **Confidence:** HIGH
 
 ## System Overview
@@ -66,7 +67,7 @@ Claude Code (LLM)
          DDG Lite / HTTP fetch
 ```
 
-**Mechanism:** PreToolUse hooks in plugin.json intercept built-in tool calls and deny them with a reason that instructs Claude to invoke the plugin skill instead. The existing skill + CLI script pipeline remains unchanged.
+**Mechanism:** PreToolUse hooks in `hooks/hooks.json` intercept built-in tool calls and deny them with a reason that instructs Claude to invoke the plugin skill instead. The existing skill + CLI script pipeline remains unchanged.
 
 ### Rejected Alternative: MCP Server Approach
 
@@ -107,28 +108,29 @@ Claude Code (LLM)
 | `skills/websearch/SKILL.md` | Skill definition with Bash invocation | YES -- minor description update |
 | `skills/webfetch/SKILL.md` | Skill definition with Bash invocation | YES -- minor description update |
 | `build.ts` | esbuild bundling to skills/*/scripts/*.cjs | NO |
-| `.claude-plugin/plugin.json` | Plugin manifest | YES -- add hooks |
+| `.claude-plugin/plugin.json` | Plugin manifest | NO -- see As-built below |
 | `skills/*/scripts/*.cjs` | Bundled CLI scripts | NO (rebuilt from source) |
 
 ### New Components
 
 | Component | Responsibility | Type |
 |-----------|---------------|------|
-| `hooks/deny-builtins.sh` (or inline in plugin.json) | PreToolUse hook that denies WebSearch/WebFetch with redirect reason | Shell script or inline echo |
+| `hooks/hooks.json` | PreToolUse hooks that deny WebSearch/WebFetch with a redirect reason | Config file with inline `echo` commands |
 
 ### Modified Components
 
 | Component | Change | Why |
 |-----------|--------|-----|
-| `.claude-plugin/plugin.json` | Add `hooks` key with PreToolUse matchers for `WebSearch` and `WebFetch` | Intercept and deny built-in tool calls |
-| `skills/websearch/SKILL.md` | Update description to mention "Use when built-in WebSearch is unavailable" | Reinforce redirect behavior after deny |
-| `skills/webfetch/SKILL.md` | Update description to mention "Use when built-in WebFetch is unavailable" | Reinforce redirect behavior after deny |
+| `skills/websearch/SKILL.md` | Description opens with "Replacement for built-in WebSearch" | Reinforce redirect behavior after deny |
+| `skills/webfetch/SKILL.md` | Description opens with "Replacement for built-in WebFetch" | Reinforce redirect behavior after deny |
+
+**As-built:** `.claude-plugin/plugin.json` was not modified. The hooks live in the auto-discovered `hooks/hooks.json` at the plugin root, and adding a `hooks` key to the manifest as well makes Claude Code load the same file twice and fail with "Duplicate hooks file detected". No shell script was needed either -- each matcher runs an inline `echo`.
 
 ## Integration Points
 
-### 1. Plugin hooks in plugin.json (PRIMARY)
+### 1. Plugin hooks in hooks/hooks.json (PRIMARY)
 
-**Integration point:** The `hooks` key in plugin.json supports inline PreToolUse hook definitions.
+**Integration point:** `hooks/hooks.json` at the plugin root is loaded automatically and supports inline PreToolUse hook definitions.
 
 **Documented behavior (HIGH confidence, Context7 verified):**
 - `matcher` field accepts tool names: `WebSearch`, `WebFetch`
@@ -137,13 +139,9 @@ Claude Code (LLM)
 - `permissionDecisionReason` is shown to Claude as guidance for what to do instead
 - Plugin hooks fire automatically when plugin is enabled
 
-**Example plugin.json with hooks:**
+**As-built hooks/hooks.json:**
 ```json
 {
-  "name": "cc-websearch",
-  "displayName": "WebSearch",
-  "version": "0.2.0",
-  "description": "DDG-powered WebSearch and WebFetch replacement for Claude Code",
   "hooks": {
     "PreToolUse": [
       {
@@ -151,7 +149,7 @@ Claude Code (LLM)
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"The built-in WebSearch tool is replaced by the cc-websearch plugin. Use the cc-websearch:websearch Skill instead with the same query.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WebSearch tool is unavailable. Use cc-websearch:websearch Skill instead.\"}}'"
           }
         ]
       },
@@ -160,7 +158,7 @@ Claude Code (LLM)
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"The built-in WebFetch tool is replaced by the cc-websearch plugin. Use the cc-websearch:webfetch Skill instead with the same url.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WebFetch tool is unavailable. Use cc-websearch:webfetch Skill instead.\"}}'"
           }
         ]
       }
@@ -168,6 +166,8 @@ Claude Code (LLM)
   }
 }
 ```
+
+The shipped wording is terser than the draft above it -- "WebSearch tool is unavailable" rather than "is replaced by the cc-websearch plugin" -- which matches Anti-Pattern 4 below.
 
 **Source:** Official Claude Code docs -- hooks reference, hooks guide, plugins reference. All verified via Context7. HIGH confidence.
 
@@ -201,7 +201,7 @@ This pipeline is stable and does not need modification for v1.2.
 
 **Why not used:**
 - `permissions.deny` in settings.json also blocks built-in tools, but requires user-side configuration
-- Plugin hooks in plugin.json are automatic -- no user action needed
+- Plugin hooks in `hooks/hooks.json` are automatic -- no user action needed
 - If plugin hooks prove unreliable, `permissions.deny` is a fallback requiring manual setup
 
 **Format for reference:**
@@ -302,7 +302,7 @@ This pipeline is stable and does not need modification for v1.2.
 
 **What:** Instructing users to add `permissions.deny` to their settings.json.
 **Why bad:** Plugin should work out of the box. Requiring manual configuration defeats the purpose of a plugin.
-**Instead:** Use plugin.json hooks for automatic interception.
+**Instead:** Use the plugin's `hooks/hooks.json` for automatic interception.
 
 ### Anti-Pattern 4: Over-Engineering the Denial Reason
 
@@ -314,9 +314,9 @@ This pipeline is stable and does not need modification for v1.2.
 
 ### Phase 1: Hook Implementation (Foundation)
 
-**What:** Add PreToolUse hooks to plugin.json.
+**What:** Add PreToolUse hooks to `hooks/hooks.json`.
 **Why first:** Everything else depends on the built-in tools being blocked. Without hooks, the replacement does not work.
-**Files changed:** `.claude-plugin/plugin.json`
+**Files changed:** `hooks/hooks.json` (new)
 **Dependencies:** None (self-contained).
 
 ### Phase 2: Denial Reason Engineering (Critical)

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -2,6 +2,7 @@
 
 **Domain:** Claude Code plugin -- tool replacement via skills + hooks
 **Researched:** 2026-05-22
+**Updated:** 2026-08-29 -- reconciled with the shipped implementation
 **Confidence:** MEDIUM
 
 ## Key Constraint: No Direct Tool Replacement Mechanism Exists
@@ -117,7 +118,7 @@ Minimum features for "plugin replaces built-in WebSearch/WebFetch."
 
 ### Plugin hooks.json Structure
 
-The plugin should include a `hooks/hooks.json` file referenced from `plugin.json`:
+The plugin includes a `hooks/hooks.json` file at the plugin root. Claude Code discovers it automatically -- do not reference it from `plugin.json`, which loads it a second time and fails with "Duplicate hooks file detected":
 
 ```json
 {

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -2,6 +2,7 @@
 
 **Domain:** Replacing built-in Claude Code WebSearch/WebFetch tools with plugin skills
 **Researched:** 2026-05-22
+**Updated:** 2026-08-29 -- reconciled with the shipped implementation
 **Confidence:** HIGH
 
 ## Critical Pitfalls
@@ -56,7 +57,7 @@ Claude Code's tool system distinguishes between built-in tools (WebSearch, WebFe
 Do not rely on name shadowing. Instead, use one of these actual override mechanisms:
 1. `--disallowedTools "WebSearch" "WebFetch"` CLI flag to remove built-in tools from model context
 2. `permissions.deny: ["WebSearch", "WebFetch"]` in settings.json
-3. PreToolUse hooks with matcher `WebSearch|WebFetch` that deny the call and provide a reason directing the model to use the plugin skill instead
+3. PreToolUse hooks matching `WebSearch` and `WebFetch` that deny the call and provide a reason directing the model to use the plugin skill instead (as built: two separate matchers, not one alternation)
 
 **Warning signs:**
 Model uses built-in WebSearch/WebFetch instead of the plugin skill. Or model uses both -- calling built-in WebSearch AND the plugin skill for the same query.
@@ -183,9 +184,9 @@ Post-MVP -- caching is explicitly deferred per PROJECT.md.
 | Mistake | Risk | Prevention |
 |---------|------|------------|
 | Plugin skill executes arbitrary URLs without validation | SSRF attacks if model is tricked into fetching internal URLs | Validate URL scheme (https only), reject private IP ranges, match built-in's domain deny-list behavior |
-| Exposing API keys in skill output | If Perplexity or other paid API keys are logged to stderr | Never log full API keys; mask in error messages; use stderr for diagnostics only |
+| Exposing API keys in skill output | Not applicable since Phase 5 -- the plugin uses no API keys at all. Kept as a guard against reintroducing a keyed provider | Never log full API keys; mask in error messages; use stderr for diagnostics only |
 | Allowing the model to inject arbitrary JSON into stdin | Malformed or malicious input crashing the script | Use Zod validation (already implemented); reject unexpected fields |
-| Plugin hooks running arbitrary commands | Compromise if hook scripts are modified | Use `chmod` and file permissions; hooks run unsandboxed at hook trust level |
+| Plugin hooks running arbitrary commands | Compromise if hook scripts are modified | As built there is no hook script -- `hooks/hooks.json` holds a fixed inline `echo` with no interpolation of tool input, so there is nothing to tamper with short of editing the plugin itself |
 
 ## UX Pitfalls
 

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -2,21 +2,25 @@
 
 **Project:** cc-websearch
 **Researched:** 2026-05-22
+**Updated:** 2026-08-29 -- reconciled with the shipped implementation (see "As-Built" notes)
 **Focus:** Stack additions/changes for replacing Claude Code built-in WebSearch/WebFetch
 
 ## Recommended Stack Changes
 
 ### No New Runtime Dependencies Required
 
-The existing stack (TypeScript, Node.js 20+, cheerio, jsdom, Readability, Turndown, Commander) is complete for the v1.2 milestone. The tool replacement mechanism is purely a Claude Code configuration concern, not a code dependency.
+The existing stack (TypeScript, Node.js, cheerio, jsdom, Readability, Turndown) is complete for the v1.2 milestone. The tool replacement mechanism is purely a Claude Code configuration concern, not a code dependency.
 
-### What Changes: Plugin Configuration and Hook Script
+**As-built:** the runtime floor is now `^22.22.2 || ^24.15.0 || >=26.0.0` (`engines` in `package.json`), raised by jsdom 30; CI runs on Node 24. `commander` and `duck-duck-scrape` are still listed as dependencies but nothing imports them -- DDG Lite is scraped with the global `fetch` plus `cheerio`, and both CLI entry points read JSON from stdin rather than parsing flags. Both should be dropped.
+
+### What Changes: Plugin Configuration
 
 | Component | Version | Purpose | Why |
 |-----------|---------|---------|-----|
-| `hooks/hooks.json` (new) | N/A | Plugin-level PreToolUse hook to intercept built-in WebSearch/WebFetch | Claude Code plugins can declare hooks in their manifest. A PreToolUse hook matching `WebSearch\|WebFetch` can deny the built-in tool call and instruct Claude to use plugin skills instead. |
-| Hook script (new shell/Node) | N/A | Executed by PreToolUse hook, returns deny decision with redirect instruction | The hook receives tool input as JSON on stdin, outputs JSON with `permissionDecision: "deny"` and a `permissionDecisionReason` telling Claude to use the plugin skill. |
-| `plugin.json` (update) | N/A | Add `hooks` field pointing to hooks configuration | Enables the plugin to register its own hooks without requiring user manual configuration. |
+| `hooks/hooks.json` (new) | N/A | Plugin-level PreToolUse hook to intercept built-in WebSearch/WebFetch | Claude Code loads the standard `hooks/hooks.json` automatically. A PreToolUse hook matching the built-in tool can deny the call and instruct Claude to use the plugin skill instead. |
+| Inline `echo` command | N/A | Executed by PreToolUse hook, returns deny decision with redirect instruction | The hook writes a fixed JSON object with `permissionDecision: "deny"` and a `permissionDecisionReason` telling Claude to use the plugin skill. |
+
+**As-built:** the planned separate hook script was not needed. `hooks/hooks.json` declares two matchers -- `WebSearch` and `WebFetch` -- each running an inline `echo` of the deny JSON. No shell script, no `jq`, and no `hooks` field in `plugin.json`: the standard path is discovered automatically, and pointing the manifest at it as well produces a duplicate-hooks load error.
 
 ### Configuration Mechanisms (No New Dependencies)
 
@@ -24,7 +28,7 @@ The existing stack (TypeScript, Node.js 20+, cheerio, jsdom, Readability, Turndo
 |-----------|-------|--------------|-------------------|
 | `permissions.deny` in settings.json | User/Project/Managed | Bare tool names (e.g., `"WebSearch"`, `"WebFetch"`) remove the tool from the model's context entirely | Most reliable: the model never sees WebSearch/WebFetch as available tools, so it must use plugin skills. But requires user to configure settings.json -- not automatable from a plugin. |
 | `--disallowedTools` CLI flag | Session | `"WebSearch" "WebFetch"` as bare names removes from model context | Same effect as permissions.deny but per-invocation. Not persistent. |
-| Plugin `hooks/hooks.json` with PreToolUse | Plugin (automatic) | Matcher `"WebSearch\|WebFetch"` triggers a hook script that denies the call with a redirect reason | Plugin-controlled, no user configuration needed. The built-in tool still appears in the model's context, but the hook blocks every invocation and tells Claude to use the skill instead. |
+| Plugin `hooks/hooks.json` with PreToolUse | Plugin (automatic) | Matchers `WebSearch` and `WebFetch` each run an inline `echo` that denies the call with a redirect reason | Plugin-controlled, no user configuration needed. The built-in tool still appears in the model's context, but the hook blocks every invocation and tells Claude to use the skill instead. |
 | `--tools` CLI flag | Session | Whitelist approach: only list tools you want, omit WebSearch/WebFetch | Draconian: removes ALL unlisted built-in tools, not viable for general use. |
 
 ## Recommended Approach: Plugin PreToolUse Hook
@@ -32,7 +36,7 @@ The existing stack (TypeScript, Node.js 20+, cheerio, jsdom, Readability, Turndo
 ### Why This Approach
 
 1. **Plugin-controlled:** Works automatically when the plugin is installed. No user configuration of settings.json required.
-2. **Declarative:** The hook is defined in the plugin's `hooks/hooks.json`, referenced from `plugin.json`.
+2. **Declarative:** The hook is defined in the plugin's `hooks/hooks.json`, which Claude Code discovers on its own.
 3. **Graceful redirect:** The deny reason tells Claude to use the plugin skill instead, so Claude learns the correct behavior.
 4. **Idempotent:** If the user also configures `permissions.deny`, the hook simply never fires (the tool is already removed from context). No conflict.
 
@@ -41,15 +45,14 @@ The existing stack (TypeScript, Node.js 20+, cheerio, jsdom, Readability, Turndo
 When Claude attempts to call the built-in `WebSearch` or `WebFetch` tool:
 
 1. Claude emits a tool_use for `WebSearch` or `WebFetch`
-2. The PreToolUse hook fires (matcher: `"WebSearch|WebFetch"`)
-3. The hook script reads the tool input from stdin (JSON with query/url)
-4. The hook script outputs a deny decision with a redirect message:
+2. The PreToolUse hook fires (matcher: `WebSearch` or `WebFetch`)
+3. The hook ignores its stdin and writes a fixed deny decision:
    ```json
    {
      "hookSpecificOutput": {
        "hookEventName": "PreToolUse",
        "permissionDecision": "deny",
-       "permissionDecisionReason": "Built-in WebSearch is disabled. Use the websearch plugin skill instead: echo '{\"query\":\"YOUR_QUERY\"}' | node \"${CLAUDE_PLUGIN_ROOT}/skills/websearch/scripts/websearch.cjs\""
+       "permissionDecisionReason": "WebSearch tool is unavailable. Use cc-websearch:websearch Skill instead."
      }
    }
    ```
@@ -78,29 +81,30 @@ PostToolUse hooks with `updatedToolOutput` can replace a tool's output after exe
 
 ## Implementation Architecture
 
-### New Files
+### New Files (as built)
 
 ```
 cc-websearch/
   hooks/
-    hooks.json                    # Plugin hook configuration
-    intercept-web-tools.sh        # PreToolUse hook script
-  .claude-plugin/
-    plugin.json                   # Updated: add "hooks" field
+    hooks.json                    # Plugin hook configuration -- auto-discovered
 ```
 
+`.claude-plugin/plugin.json` was left unchanged: no `hooks` field is needed or wanted.
+
 ### hooks/hooks.json
+
+Two separate matchers rather than the alternation `"WebSearch|WebFetch"` originally sketched, because each tool needs its own skill name in the deny reason:
 
 ```json
 {
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "WebSearch|WebFetch",
+        "matcher": "WebSearch",
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/intercept-web-tools.sh"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"WebSearch tool is unavailable. Use cc-websearch:websearch Skill instead.\"}}'"
           }
         ]
       }
@@ -109,51 +113,29 @@ cc-websearch/
 }
 ```
 
-### hooks/intercept-web-tools.sh
+The `WebFetch` matcher is identical apart from the tool and skill names. Because the command is a fixed `echo`, the hook never reads its stdin -- the query or URL is not echoed back, and the reason names the skill instead of a ready-made shell command.
 
-The script reads JSON stdin, identifies the tool, and returns a deny decision with the appropriate skill invocation command. Must be executable (`chmod +x`).
-
-Input (from Claude Code):
-```json
-{
-  "hook_event_name": "PreToolUse",
-  "tool_name": "WebSearch",
-  "tool_input": {
-    "query": "search terms"
-  }
-}
-```
-
-Output (from script):
-```json
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "deny",
-    "permissionDecisionReason": "Use the cc-websearch plugin skill instead: echo '{\"query\":\"search terms\"}' | node \"${CLAUDE_PLUGIN_ROOT}/skills/websearch/scripts/websearch.cjs\""
-  }
-}
-```
-
-### .claude-plugin/plugin.json (updated)
+### .claude-plugin/plugin.json (unchanged)
 
 ```json
 {
   "name": "cc-websearch",
   "displayName": "WebSearch",
-  "version": "0.2.0",
-  "description": "DDG-powered WebSearch and WebFetch replacement for Claude Code",
-  "hooks": "./hooks/hooks.json"
+  "version": "1.2.4",
+  "description": "DDG-powered WebSearch and WebFetch replacement for Claude Code"
 }
 ```
+
+The `version` here is duplicated from `package.json` and the two must be bumped together.
 
 ## Stack NOT to Add
 
 | Avoid | Why | Use Instead |
 |-------|-----|-------------|
 | MCP server implementation | Project constraint: skills call CLI scripts directly. MCP tools use different routing (`mcp__server__tool`) and would not replace built-in tools named `WebSearch`/`WebFetch`. | PreToolUse hook + existing skill scripts |
-| Any new npm dependency | The hook script is a simple shell script that parses JSON with `jq` (standard on macOS/Linux) and outputs JSON. No Node.js needed for the hook itself. | `jq` (already standard CLI tool) or pure bash with heredoc |
+| Any new npm dependency | The hook emits a fixed JSON string. It does not parse its input, so it needs neither Node.js nor `jq`. | A single inline `echo` in `hooks/hooks.json` |
 | `permissions.deny` auto-configuration | A plugin cannot programmatically modify the user's settings.json. Claude Code has no plugin API for this. | PreToolUse hook (automatic) + documentation for manual `permissions.deny` |
+| `hooks` field in `plugin.json` | The standard `hooks/hooks.json` is loaded automatically. Declaring it in the manifest too resolves to the same file and fails with "Duplicate hooks file detected". | Rely on auto-discovery; leave the manifest alone |
 | Skill `disallowedTools` frontmatter | This field exists for subagents, not for the main conversation agent. It restricts tools for agents spawned BY the skill, not the skill's own conversation. | PreToolUse hook at plugin level |
 
 ## Token Cost Analysis
@@ -173,7 +155,7 @@ The token cost is minimal because Claude Code uses prompt caching -- the tool de
 |---------|------------|--------|
 | PreToolUse hooks match on WebSearch/WebFetch | HIGH | Context7: code.claude.com docs, hooks reference explicitly lists these tool names |
 | PreToolUse deny with reason causes Claude to adapt | HIGH | Context7: Official docs show deny + reason pattern |
-| Plugin can declare hooks via hooks.json in plugin.json | HIGH | Context7: plugins-reference shows `"hooks": "./hooks/hooks.json"` |
+| Plugin hooks load from `hooks/hooks.json` without a manifest entry | HIGH | As-built: the standard path is auto-discovered; a manifest `hooks` field duplicates it and errors |
 | Bare tool names in permissions.deny remove from context | HIGH | Context7: CLI reference and permissions docs confirm |
 | Plugin cannot programmatically modify settings.json | HIGH | Context7: No API for this; strictPluginOnlyCustomization exists for locking surfaces |
 | PostToolUse updatedToolOutput works for all tools | HIGH | Context7: Week 18 2026 changelog confirms this is now universal |

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -3,13 +3,14 @@
 **Project:** cc-websearch
 **Domain:** Claude Code plugin -- built-in tool replacement via PreToolUse hooks
 **Researched:** 2026-05-22
+**Updated:** 2026-08-29 -- reconciled with the shipped implementation
 **Confidence:** HIGH
 
 ## Executive Summary
 
 cc-websearch is a Claude Code plugin that provides WebSearch and WebFetch capabilities via DDG-powered CLI scripts invoked through plugin skills. The v1.2 milestone replaces the built-in WebSearch and WebFetch tools so the plugin takes over transparently. The core challenge is architectural: Claude Code has no native tool-replacement mechanism. Skills and built-in tools are separate systems -- skills run through the `Skill` tool and are namespaced (`cc-websearch:websearch`), so they cannot shadow or override built-in tool names like `WebSearch` or `WebFetch`.
 
-The recommended approach is a two-part strategy using PreToolUse hooks declared in `plugin.json`. First, hooks matching `WebSearch` and `WebFetch` deny every invocation of the built-in tools with a `permissionDecision: "deny"` response. Second, the denial reason (`permissionDecisionReason`) instructs Claude to invoke the plugin skill instead. This is a behavioral redirect, not a structural replacement -- the model receives the denial reason and must choose to follow it. The existing skill scripts, build pipeline, and output formats remain unchanged; only `plugin.json`, a hook configuration, and skill descriptions need modification.
+The recommended approach is a two-part strategy using PreToolUse hooks declared in `hooks/hooks.json`. First, hooks matching `WebSearch` and `WebFetch` deny every invocation of the built-in tools with a `permissionDecision: "deny"` response. Second, the denial reason (`permissionDecisionReason`) instructs Claude to invoke the plugin skill instead. This is a behavioral redirect, not a structural replacement -- the model receives the denial reason and must choose to follow it. The existing skill scripts, build pipeline, and output formats remain unchanged; only a hook configuration and the skill descriptions need modification. **As built, `plugin.json` was not touched at all** -- `hooks/hooks.json` is discovered automatically.
 
 The primary risk is redirect reliability. The denial reason is a string that becomes part of the model's context, but the model's next action is not guaranteed. Mitigations include explicit skill naming in the denial reason, reinforced skill descriptions that self-document their purpose, and optional `permissions.deny` configuration for users who want belt-and-suspenders reliability. A secondary risk is output format parity between the built-in WebFetch (which may return structured JSON) and the plugin (which returns raw markdown) -- this needs empirical verification against actual Claude Code behavior.
 
@@ -17,12 +18,15 @@ The primary risk is redirect reliability. The denial reason is a string that bec
 
 ### Recommended Stack
 
-No new runtime dependencies are required. The existing stack (TypeScript, Node.js 20+, cheerio, jsdom, Readability, Turndown, Commander, Zod) is complete. The v1.2 change is purely a plugin configuration concern.
+No new runtime dependencies are required. The existing stack (TypeScript, Node, cheerio, jsdom, Readability, Turndown, Zod) is complete. The v1.2 change is purely a plugin configuration concern.
+
+**As-built:** the runtime floor is `^22.22.2 || ^24.15.0 || >=26.0.0` (raised by jsdom 30; CI runs Node 24). `Commander` is listed above in the original research but nothing imports it, nor `duck-duck-scrape` -- both are dead dependencies.
 
 **New components:**
-- PreToolUse hooks in `plugin.json` (or `hooks/hooks.json`): inline `echo` commands that output deny decisions with redirect reasons. No shell script or `jq` dependency needed.
-- Updated `plugin.json` manifest: adds a `hooks` key with PreToolUse matchers for `WebSearch` and `WebFetch`.
+- PreToolUse hooks in `hooks/hooks.json`: inline `echo` commands that output deny decisions with redirect reasons. No shell script or `jq` dependency needed.
+- Two separate matchers, `WebSearch` and `WebFetch`, so each deny reason can name its own skill.
 - Updated SKILL.md descriptions: add language reinforcing skill availability when built-in tools are denied.
+- No `hooks` key in the manifest: declaring the standard path there loads it twice and fails.
 
 ### Expected Features
 
@@ -49,17 +53,16 @@ No new runtime dependencies are required. The existing stack (TypeScript, Node.j
 
 ### Architecture Approach
 
-The architecture adds a hook-based interception layer on top of the existing skill invocation pipeline. PreToolUse hooks in `plugin.json` deny built-in tool calls and redirect to plugin skills. The existing skill-to-Bash-to-CLI-script chain remains unchanged. This is the only viable approach -- MCP servers cannot match built-in tool names (`mcp__server__tool` naming convention), skills cannot shadow built-in names (they are namespaced), and `permissions.deny` requires manual user configuration.
+The architecture adds a hook-based interception layer on top of the existing skill invocation pipeline. PreToolUse hooks in `hooks/hooks.json` deny built-in tool calls and redirect to plugin skills. The existing skill-to-Bash-to-CLI-script chain remains unchanged. This is the only viable approach -- MCP servers cannot match built-in tool names (`mcp__server__tool` naming convention), skills cannot shadow built-in names (they are namespaced), and `permissions.deny` requires manual user configuration.
 
 **Major components (existing, unchanged):**
 1. `src/websearch.ts` / `src/webfetch.ts` -- CLI entry points
 2. `src/lib/duckduckgo.ts`, `src/lib/content.ts`, `src/lib/fetch.ts` -- search, extraction, HTTP
 3. `build.ts` -- esbuild bundling to `skills/*/scripts/*.cjs`
 
-**New/modified components:**
-1. `plugin.json` -- add `hooks` key with inline PreToolUse matchers
-2. `hooks/hooks.json` (alternative) -- external hook configuration file
-3. `skills/websearch/SKILL.md`, `skills/webfetch/SKILL.md` -- update descriptions
+**New/modified components (as built):**
+1. `hooks/hooks.json` -- inline PreToolUse matchers, auto-discovered
+2. `skills/websearch/SKILL.md`, `skills/webfetch/SKILL.md` -- update descriptions
 
 ### Critical Pitfalls
 
@@ -67,25 +70,25 @@ The architecture adds a hook-based interception layer on top of the existing ski
 2. **Denial reason redirect is behavioral, not guaranteed** -- After a deny, the model receives the reason string and decides what to do next. It may retry, fall back to Bash+curl, or ask the user. Mitigate with explicit skill naming, directive language, and testing across prompt patterns.
 3. **Built-in WebSearch does not exist on non-Anthropic providers** -- On Bedrock, Vertex, OpenAI-compatible endpoints, the built-in tool is hidden entirely. The plugin must provide self-contained search that works regardless of provider. The skill descriptions must not assume the model knows about built-in WebSearch/WebFetch.
 4. **Built-in WebFetch runs a Haiku summarization pass** -- The built-in tool fetches, converts to markdown, truncates to 100KB, then runs a Haiku model pass to answer the user's prompt. The plugin returns raw markdown without LLM summarization. This is a deliberate design difference, but the plugin should implement 100KB truncation to match.
-5. **PreToolUse hook matcher is case-sensitive** -- Tool names must be `WebSearch|WebFetch` (exact case). Using lowercase will silently fail to match.
+5. **PreToolUse hook matcher is case-sensitive** -- Tool names must be `WebSearch` and `WebFetch` (exact case). Using lowercase will silently fail to match.
 
 ## Implications for Roadmap
 
 Based on combined research, the v1.2 work is narrow in scope (no new runtime code, only plugin configuration and testing) but high in risk (behavioral redirect reliability). The phases should be structured around the dependency chain: hooks first (foundation), then denial reason tuning (critical link), then validation.
 
 ### Phase 1: Hook Infrastructure
-**Rationale:** Everything depends on the built-in tools being intercepted. Without hooks, the replacement mechanism does not exist. This is the smallest possible change (plugin.json only) but the most important.
+**Rationale:** Everything depends on the built-in tools being intercepted. Without hooks, the replacement mechanism does not exist. This is the smallest possible change (one config file) but the most important.
 **Delivers:** Plugin that automatically blocks built-in WebSearch/WebFetch when installed.
 **Addresses:** Table stakes features -- built-in WebSearch blocked, built-in WebFetch blocked.
 **Avoids:** Pitfalls 1 (skills cannot shadow names) and 5 (case-sensitive matchers).
-**Files:** `.claude-plugin/plugin.json`, optionally `hooks/hooks.json`.
+**Files:** `hooks/hooks.json`.
 
 ### Phase 2: Denial Reason Engineering and Skill Description Tuning
 **Rationale:** The denial reason is the critical behavioral link. If Claude does not follow the redirect instruction, the whole replacement fails. This phase requires iterative testing with diverse prompt patterns.
 **Delivers:** Reliable redirect from denied built-in tool to plugin skill invocation.
 **Addresses:** Table stakes -- skill invocation works after deny; differentiators -- no API key, provider-agnostic.
 **Avoids:** Pitfalls 2 (behavioral redirect) and 3 (non-Anthropic providers).
-**Files:** `.claude-plugin/plugin.json` (denial reason text), `skills/websearch/SKILL.md`, `skills/webfetch/SKILL.md`.
+**Files:** `hooks/hooks.json` (denial reason text), `skills/websearch/SKILL.md`, `skills/webfetch/SKILL.md`.
 
 ### Phase 3: Output Format Verification and Cross-Provider Testing
 **Rationale:** Output format parity must be verified empirically. The WebFetch output format gap (raw markdown vs structured JSON) is a MEDIUM risk that needs testing against actual Claude Code behavior. Cross-provider testing ensures the plugin works where the built-in does not.
@@ -99,7 +102,7 @@ Based on combined research, the v1.2 work is narrow in scope (no new runtime cod
 - Phase 1 is a configuration-only change with zero risk of breaking existing plugin functionality. It must come first because Phase 2 and Phase 3 depend on hooks being in place.
 - Phase 2 is the highest-risk phase because redirect reliability is behavioral, not structural. It must come before Phase 3 because format verification requires a working end-to-end redirect.
 - Phase 3 is validation and adjustment. It comes last because it assumes the redirect mechanism works and focuses on output correctness.
-- The entire v1.2 scope is 3-5 files total (plugin.json, optionally hooks.json, two SKILL.md files, possibly one source file for format adjustment). This is deliberately narrow.
+- The entire v1.2 scope is 3-5 files total (hooks.json, two SKILL.md files, possibly one source file for format adjustment). This is deliberately narrow.
 
 ### Research Flags
 
@@ -122,6 +125,8 @@ Phases with standard patterns (skip research-phase):
 **Overall confidence:** HIGH
 
 ### Gaps to Address
+
+All three were closed during implementation; kept here as the record of what needed proving.
 
 - **Redirect reliability is untested:** Research confirms the mechanism (PreToolUse deny with reason) exists and is documented. Research does not provide empirical redirect success rates. Phase 2 must include testing across diverse prompt patterns to measure and improve reliability.
 - **WebFetch output format needs empirical verification:** Agent SDK types show structured JSON with `bytes`, `code`, `codeText`, `result`, `durationMs`, `url` fields. Whether the conversation-visible output is the full JSON or just the `result` field is unclear. Phase 3 must test against actual Claude Code behavior.
@@ -148,4 +153,5 @@ Phases with standard patterns (skip research-phase):
 
 ---
 *Research completed: 2026-05-22*
-*Ready for roadmap: yes*
+*Reconciled with shipped code: 2026-08-29*
+*Ready for roadmap: yes (milestone since shipped)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,24 @@
 
 ## Project
 
-**cc-websearch**
+**cc-websearch** — a Claude Code plugin providing two skills, `websearch` and `webfetch`, that
+replace the built-in WebSearch and WebFetch tools. Each skill invokes a bundled Node CLI script that
+reads JSON on stdin and writes results to stdout, producing output identical to the built-in tools.
 
-A Claude Code plugin providing two skills that replace the built-in WebSearch and WebFetch tools. Distributed as a standard Claude Code plugin installable via the plugin command. Two Node CLI scripts (`websearch`, `webfetch`) called via `node` from skill definitions, producing output identical to Claude Code's built-in tools.
-
-**Core Value:** Exact drop-in replacement for Claude Code's WebSearch and WebFetch — same interface, same output format, no behavior changes for the user.
+**Core value:** exact drop-in replacement — same interface, same output format, no API keys.
 
 ### Constraints
 
-- **Runtime**: TypeScript/Node — scripts run via `node`
-- **Distribution**: Standard Claude Code plugin — installable via plugin command
-- **Output format**: Must match Claude Code's WebSearch and WebFetch output byte-for-byte
-- **Perplexity API**: Chat Completions endpoint
-- **DDG API**: DuckDuckGo Lite HTML scraping
-- **Config**: `~/.config/websearch/config.json` or environment variables
+- **Runtime**: TypeScript compiled to CommonJS bundles; Node `^22.22.2 || ^24.15.0 || >=26.0.0`
+  (see `engines` in `package.json`). CI runs on Node 24.
+- **Distribution**: standard Claude Code plugin. Bundles are committed to git, so the plugin works
+  immediately after install with no build step.
+- **Output format**: must match Claude Code's built-in WebSearch/WebFetch byte-for-byte.
+- **Search backend**: DuckDuckGo Lite (`lite.duckduckgo.com`) scraped with the global `fetch` and
+  `cheerio`. No API keys, no accounts.
+- **No LLM in the pipeline**: WebFetch extracts and converts page content; it never answers the
+  `prompt` field.
+- **Config**: `~/.config/websearch/config.json`, overridden by `WEBSEARCH_*` environment variables.
 
 <!-- GSD:project-end -->
 
@@ -23,119 +27,35 @@ A Claude Code plugin providing two skills that replace the built-in WebSearch an
 
 ## Technology Stack
 
-## Recommended Stack
+Versions below are the current pins; `package.json` is the source of truth.
 
-### Core Technologies
+| Package                               | Version    | Purpose                                           |
+| ------------------------------------- | ---------- | ------------------------------------------------- |
+| `zod`                                 | 4.4.3      | Stdin/config schema validation (`z.strictObject`) |
+| `cheerio`                             | ^1.2.0     | Parsing DDG Lite search-result HTML               |
+| `@mozilla/readability`                | ^0.6.0     | Article extraction (Firefox Reader View engine)   |
+| `jsdom`                               | ^30.0.1    | DOM implementation required by Readability        |
+| `turndown`                            | ^7.2.4     | HTML → Markdown                                   |
+| `turndown-plugin-gfm`                 | ^1.0.2     | GFM tables and strikethrough for Turndown         |
+| `typescript`                          | 6.0.3      | Language / `tsc --noEmit` typechecking            |
+| `esbuild`                             | 0.28.2     | Production bundling to `.cjs`                     |
+| `tsx`                                 | 4.23.12    | Runs `build.ts` without a compile step            |
+| `vitest` + `@vitest/coverage-v8`      | 4.1.x      | Unit and e2e tests                                |
+| `eslint` + `typescript-eslint`        | 10.x / 8.x | Linting (`recommended` + `strict`)                |
+| `prettier` + `eslint-config-prettier` | 3.x / 10.x | Formatting                                        |
 
-| Technology                     | Version | Purpose                       | Why Recommended                                                                                                                                                                                        |
-| ------------------------------ | ------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| TypeScript                     | 5.x     | Language                      | Claude Code plugins run via `node`; TypeScript provides type safety for CLI input parsing, API response handling, and config validation. The ecosystem strongly favors TS.                             |
-| Node.js                        | 20 LTS+ | Runtime                       | Required by Claude Code plugin system (`node` command in skill definitions). v20 LTS is the current long-term support line.                                                                            |
-| Commander.js                   | 13.x    | CLI argument parsing          | De facto standard for Node CLI apps. Supports hybrid input: flags for simple queries plus `parseAsync()` for programmatic use. TypeScript-native, zero dependencies, well-maintained.                  |
-| `@perplexity-ai/perplexity_ai` | 2.x     | Perplexity API client         | Official Perplexity TypeScript SDK. Supports Chat Completions (sonar models) with built-in retries, timeouts, error handling, and streaming. OpenAI-compatible response format with `citations` array. |
-| `duck-duck-scrape`             | 2.2.x   | DuckDuckGo fallback           | Node.js library for scraping DDG search results without API keys. Supports text, image, video, news search. The only maintained DDG scraping library in the ecosystem.                                 |
-| `turndown`                     | 7.2.x   | HTML to Markdown conversion   | Standard HTML-to-Markdown converter for JavaScript. Used by Firefox, Joplin, and countless tools. Extensible rule system, plugin support for GFM tables.                                               |
-| `@mozilla/readability`         | 0.6.x   | Content extraction            | Firefox Reader View engine. Extracts article content from HTML, stripping navigation, ads, sidebars. The proven solution for clean content extraction.                                                 |
-| `jsdom`                        | 25.x    | DOM parsing for Readability   | Required by `@mozilla/readability` (needs a `document` object). jsdom provides a W3C-compliant DOM in Node.js. The standard pairing with Readability.                                                  |
-| `cheerio`                      | 1.x     | HTML parsing for DDG scraping | Lightweight jQuery-style HTML parser. Used to parse DuckDuckGo Lite HTML search results. Far lighter than jsdom for simple scraping -- no full DOM needed.                                             |
+`package.json` still lists two dependencies that nothing imports: `commander` (there is no CLI flag
+parsing — input arrives as JSON on stdin) and `duck-duck-scrape` (replaced by `fetch` + `cheerio`).
+Neither ends up in the bundles. They only generate Dependabot noise and should be dropped.
 
-### Supporting Libraries
+### What not to add
 
-| Library               | Version | Purpose                        | When to Use                                                                                                                        |
-| --------------------- | ------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `zod`                 | 3.x     | Schema validation              | Validate JSON stdin input matching Claude Code's WebSearch/WebFetch tool schemas. Runtime type checking with TypeScript inference. |
-| `turndown-plugin-gfm` | 1.0.x   | GFM table support for Turndown | Always -- web pages contain tables. Enables GitHub Flavored Markdown table conversion.                                             |
-| `p-limit`             | 6.x     | Concurrency control            | If batching multiple DDG scrape requests. Prevents rate-limiting from aggressive parallel requests.                                |
-
-### Development Tools
-
-| Tool           | Purpose                       | Notes                                                                                                                             |
-| -------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `tsx`          | Dev-time TypeScript execution | Run `.ts` files directly with `npx tsx script.ts`. No build step during development. Powered by esbuild.                          |
-| `vitest`       | Testing framework             | Fast, ESM-native, TypeScript-first testing. Supports mocking HTTP requests via `vi.fn()`. Vite-powered.                           |
-| `tsc --noEmit` | Type checking                 | Run in CI for full type safety. esbuild/tsx skip type checking, so this catches errors they miss.                                 |
-| `esbuild`      | Production bundling           | Bundle CLI scripts into single files for distribution. Use directly (not tsup) since these are standalone scripts, not libraries. |
-
-## Installation
-
-# Core runtime dependencies
-
-# Dev dependencies
-
-## Alternatives Considered
-
-| Category            | Recommended                                   | Alternative                                      | When to Use Alternative                                                                                                                                                                                                                              |
-| ------------------- | --------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Perplexity client   | `@perplexity-ai/perplexity_ai` (official SDK) | Raw `fetch` to OpenAI-compatible endpoint        | If SDK adds unwanted bundle size or you need minimal dependencies. Perplexity API is OpenAI-compatible so a raw `fetch` with `Authorization` header works. However, the SDK provides retry logic, typed responses, and error classes out of the box. |
-| Perplexity client   | `@perplexity-ai/perplexity_ai`                | `@ai-sdk/perplexity` (Vercel AI SDK provider)    | Only if already using Vercel AI SDK elsewhere. Adds unnecessary dependency weight for a standalone CLI.                                                                                                                                              |
-| DDG scraping        | `duck-duck-scrape`                            | Raw `fetch` + `cheerio` on `lite.duckduckgo.com` | If `duck-duck-scrape` breaks due to DDG HTML changes and needs a quick patch. The library abstracts the HTML structure, which is fragile.                                                                                                            |
-| HTML to Markdown    | `turndown`                                    | `node-html-markdown`                             | If Turndown's CommonMark output is too limited. `node-html-markdown` (v2.0) is faster but less mature, with fewer plugins. Turndown's plugin ecosystem (GFM, tables, strikethrough) makes it more flexible.                                          |
-| DOM for Readability | `jsdom`                                       | `linkedom`                                       | If jsdom's ~2MB size is unacceptable. `linkedom` is lighter but missing some DOM APIs that Readability depends on. jsdom is the officially tested pairing.                                                                                           |
-| CLI parsing         | `commander`                                   | `yargs`                                          | If you need advanced features like shell completion, internationalization, or deep subcommand nesting. Commander is simpler and more than sufficient for two scripts with a handful of flags.                                                        |
-| CLI parsing         | `commander`                                   | Raw `process.argv` parsing                       | Only for the simplest one-flag scripts. Not worth it -- Commander adds negligible overhead and handles edge cases (quoted args, variadic, help text, etc.).                                                                                          |
-| Config parsing      | `zod`                                         | `joi` or `ajv`                                   | If you prefer JSON Schema validation (ajv) or a different API style. Zod provides the best TypeScript inference and is the ecosystem standard in 2025.                                                                                               |
-| Build tool          | `esbuild` (direct)                            | `tsup`                                           | If building a library with multiple export formats. For standalone CLI scripts, raw esbuild is simpler and more direct.                                                                                                                              |
-
-## What NOT to Use
-
-| Avoid                     | Why                                                                                                                                               | Use Instead                                      |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| Puppeteer / Playwright    | Way too heavy for scraping DDG Lite. Launches a full browser process. DDG Lite has zero JavaScript -- a simple `fetch` is all you need.           | `duck-duck-scrape` or `cheerio` with raw `fetch` |
-| `axios`                   | Unnecessary dependency. Node 18+ has native `fetch`. The Perplexity SDK uses native `fetch` internally. Adding axios adds ~40KB for zero benefit. | Native `fetch` (global in Node 18+)              |
-| `node-fetch`              | Polyfill for older Node versions. Node 18+ includes native `fetch`. Since the project targets Node 20 LTS+, this is redundant.                    | Native `fetch` (global in Node 20 LTS)           |
-| `ts-node`                 | Slow, outdated. `tsx` is the modern replacement -- faster (esbuild-powered), better ESM support, actively maintained.                             | `tsx` for dev execution                          |
-| `jest`                    | Heavy, slow, CJS-centric. Vitest is the modern standard for TypeScript projects -- faster, ESM-native, Vite-powered.                              | `vitest`                                         |
-| MCP server implementation | Out of scope per PROJECT.md. Skills call CLI scripts directly via `node`. No MCP transport needed.                                                | CLI scripts invoked by skill definitions         |
-| `deno` or `bun` runtimes  | Claude Code invokes scripts with `node`. The runtime must be Node.js.                                                                             | Node.js 20 LTS+                                  |
-
-## Stack Patterns by Variant
-
-- Drop `@perplexity-ai/perplexity_ai` and use raw `fetch` against `https://api.perplexity.ai/chat/completions`
-- The API is OpenAI-compatible, so the request format is straightforward
-- You lose built-in retries, typed responses, and error classes, but gain zero-dependency simplicity
-- Fall back to raw `fetch` + `cheerio` targeting `lite.duckduckgo.com`
-- DDG Lite is a stable HTML-only page (`<a class="result__a">` for titles, etc.)
-- This is more fragile but gives you direct control over the parsing
-- Consider `@popplar/readability` or a simpler content extraction approach
-- But this is unlikely -- jsdom is the tested and documented pairing
-
-## Plugin Distribution Architecture
-
-- Skills invoke compiled bundles from their own subdirectory: `node "${CLAUDE_PLUGIN_ROOT}/skills/<name>/scripts/<bundle>.cjs"`
-- Use `${CLAUDE_PLUGIN_ROOT}` for all path references in skill definitions
-- Use `${CLAUDE_PLUGIN_DATA}` for persistent data (caches, node_modules across updates)
-- The `hooks/hooks.json` `SessionStart` hook pattern handles npm dependency installation on first run and after updates
-- Plugin manifests require only `name`; `version` is recommended for explicit versioning
-- `bin/` directory adds executables to PATH during Bash tool usage (not needed here -- skills call scripts directly)
-
-## Version Compatibility
-
-| Package A                          | Compatible With             | Notes                                                                         |
-| ---------------------------------- | --------------------------- | ----------------------------------------------------------------------------- |
-| `@perplexity-ai/perplexity_ai@2.x` | Node 20+                    | SDK requires Node 20 LTS or later. Uses native `fetch`.                       |
-| `@mozilla/readability@0.6.x`       | `jsdom@25.x`                | Readability requires a DOM `Document` object. jsdom is the standard provider. |
-| `turndown@7.2.x`                   | `turndown-plugin-gfm@1.0.x` | GFM plugin is the standard extension for tables and strikethrough.            |
-| `duck-duck-scrape@2.2.x`           | Node 18+                    | Uses native `fetch` internally. No browser polyfill needed.                   |
-| `commander@13.x`                   | TypeScript 4.9+             | Ships native TypeScript types. No `@types/commander` needed.                  |
-| `vitest@4.x`                       | Vite 6.x                    | Vitest 4.x is the current major version.                                      |
-| `tsx@4.x`                          | Node 18+                    | esbuild-powered TypeScript execution.                                         |
-
-## Sources
-
-- [Perplexity Node.js SDK (GitHub)](https://github.com/perplexityai/perplexity-node) -- SDK API, Chat Completions, streaming, error handling, retries. HIGH confidence.
-- [Claude Code Plugin Reference](https://code.claude.com/docs/en/plugins-reference) -- Plugin manifest schema, directory structure, skill definitions, hooks, `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}` variables. HIGH confidence.
-- [Claude Code Create Plugins](https://code.claude.com/docs/en/plugins) -- Quickstart, directory layout, testing with `--plugin-dir`. HIGH confidence.
-- [Perplexity Sonar API Docs](https://docs.perplexity.ai/docs/sonar/quickstart) -- OpenAI-compatible format, citations in response, sonar models. HIGH confidence.
-- [DuckDuckGo Non-JS Versions](https://duckduckgo.com/duckduckgo-help-pages/features/non-javascript) -- lite.duckduckgo.com and html.duckduckgo.com endpoints. HIGH confidence.
-- [duck-duck-scrape (npm)](https://www.npmjs.com/package/duck-duck-scrape) -- v2.2.7, TypeScript support, search API. HIGH confidence.
-- [turndown (npm)](https://www.npmjs.com/package/turndown) -- v7.2.0, HTML to Markdown, plugin system. HIGH confidence.
-- [@mozilla/readability (npm)](https://www.npmjs.com/package/@mozilla/readability) -- v0.6.0, Firefox Reader View engine. HIGH confidence.
-- [jsdom (npm)](https://www.npmjs.com/package/jsdom) -- v25.x, W3C DOM for Node.js. HIGH confidence.
-- [cheerio (npm)](https://www.npmjs.com/package/cheerio) -- v1.x, lightweight HTML parser. HIGH confidence.
-- [Commander.js (npm)](https://www.npmjs.com/package/commander) -- v13.x, CLI framework. HIGH confidence.
-- [vitest (npm)](https://www.npmjs.com/package/vitest) -- v4.1.6, testing framework. HIGH confidence.
-- [PkgPulse TypeScript Build Tools Guide](https://www.pkgpulse.com/guides/best-typescript-build-tools-2026) -- tsx vs tsup vs esbuild comparison. MEDIUM confidence.
-- Version numbers for turndown (7.2.0), Commander.js (13.x), and tsx (4.x) are based on npm registry data and web search results cross-referenced with official pages. Some exact patch versions may differ from latest by the time of implementation -- verify with `npm view <package> version`.
+- **HTTP clients** (`axios`, `node-fetch`) — Node's global `fetch` is used everywhere.
+- **Headless browsers** (Puppeteer, Playwright) — DDG Lite is plain HTML; a `fetch` is enough.
+- **CLI argument parsers** — both scripts take JSON on stdin only. There is no flag parsing.
+- **`ts-node`, `jest`** — the project uses `tsx` and `vitest`.
+- **MCP server code** — skills call the bundled scripts directly.
+- **Non-Node runtimes** (Deno, Bun) — Claude Code invokes the scripts with `node`.
 
 <!-- GSD:stack-end -->
 
@@ -143,7 +63,18 @@ A Claude Code plugin providing two skills that replace the built-in WebSearch an
 
 ## Conventions
 
-Conventions not yet established. Will populate as patterns emerge during development.
+- **ESM source, CJS bundles.** `package.json` sets `"type": "module"`; relative imports use the
+  `.js` extension (`./lib/input.js`) as required by `NodeNext` resolution.
+- **stdout is the result, stderr is everything else.** Logging goes exclusively to stderr;
+  `test/io-separation.test.ts` guards this. Never `console.log` in `src/`.
+- **Validation at the boundary.** All external input goes through a zod `strictObject` in
+  `src/lib/input.ts`; unknown keys are rejected.
+- **Errors set `process.exitCode = 1`** and log via the module logger — no bare `throw` from `main`.
+- **Prettier**: single quotes, semicolons, trailing commas, width 100, 2-space indent.
+  `eslint-config-prettier` must stay last in `eslint.config.js`.
+- **Generated files are not hand-edited.** `skills/*/scripts/*.cjs` and `scripts/*.cjs` come from
+  `npm run build`.
+- **Versions are duplicated** in `package.json` and `.claude-plugin/plugin.json` — bump both together.
 
 <!-- GSD:conventions-end -->
 
@@ -151,7 +82,39 @@ Conventions not yet established. Will populate as patterns emerge during develop
 
 ## Architecture
 
-Architecture not yet mapped. Follow existing patterns found in the codebase.
+| Path                    | Role                                                                 |
+| ----------------------- | -------------------------------------------------------------------- |
+| `src/websearch.ts`      | WebSearch entry point — stdin → DDG → XML on stdout                  |
+| `src/webfetch.ts`       | WebFetch entry point — stdin → fetch → Readability → markdown        |
+| `src/lib/input.ts`      | zod schemas for stdin payloads, stdin reader, domain-flag validation |
+| `src/lib/config.ts`     | Config file loading + `WEBSEARCH_*` env overrides                    |
+| `src/lib/duckduckgo.ts` | DDG search wrapper                                                   |
+| `src/lib/fetch.ts`      | HTTP fetch, HTTPS upgrade, redirect and content-type handling        |
+| `src/lib/content.ts`    | Readability extraction + Turndown (with GFM plugin) markdown output  |
+| `src/lib/filter.ts`     | `allowed_domains` / `blocked_domains` filtering                      |
+| `src/lib/retry.ts`      | Exponential backoff, transient-error classification                  |
+| `src/lib/output.ts`     | `<search_results>` XML formatting                                    |
+| `src/lib/logger.ts`     | Leveled logger — writes to stderr only                               |
+| `build.ts`              | esbuild bundling into `skills/*/scripts/*.cjs`                       |
+| `skills/*/SKILL.md`     | Skill definitions that shell out to the bundles                      |
+| `hooks/hooks.json`      | `PreToolUse` hooks denying the built-in WebSearch/WebFetch tools     |
+
+### Pipelines
+
+```
+websearch: JSON stdin → zod validate → fetch lite.duckduckgo.com → cheerio parse
+           → unwrap /l/?uddg= redirect links → domain filter
+           → <search_results> XML on stdout
+webfetch:  JSON stdin → zod validate → fetch → @mozilla/readability (jsdom)
+           → turndown → markdown on stdout
+```
+
+### Build
+
+`npm run build` runs `build.ts` under `tsx`. esbuild bundles each entry point into a single
+self-contained `.cjs` file. A custom esbuild plugin inlines jsdom's filesystem reads (default
+stylesheet, XHR sync worker) and patches `@acemir/cssom` so the bundle runs without jsdom's
+`node_modules` present — that plugin is the fragile part of the build; check it after any jsdom bump.
 
 <!-- GSD:architecture-end -->
 
@@ -189,3 +152,24 @@ Do not make direct repo edits outside a GSD workflow unless the user explicitly 
 > This section is managed by `generate-claude-profile` -- do not edit manually.
 
 <!-- GSD:profile-end -->
+
+## Commands
+
+| Command             | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `npm run check`     | Full CI equivalent: lint + typecheck + test + build        |
+| `npm run lint`      | `eslint .` then `prettier --check .`                       |
+| `npm run typecheck` | `tsc --noEmit`                                             |
+| `npm test`          | Vitest unit tests                                          |
+| `npm run build`     | Bundle both scripts with esbuild                           |
+| `npm run e2e`       | Build, then run `test/e2e/` (needs the local `claude` CLI) |
+
+`.mise.toml` mirrors these as mise tasks; npm scripts remain the primary interface.
+
+## Working agreements
+
+- Run `npm run check` before pushing — CI runs exactly these steps and fails on Prettier diffs.
+- After changing `src/` or `build.ts`, rebuild and commit the regenerated bundles, since they are
+  what users actually run.
+- Dependabot PRs that have sat open for a while are branched from a stale `master` and will fail
+  lint on unrelated files. Rebase them before judging the failure.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ No API keys, no accounts, no subscriptions. Install the plugin and start searchi
 
 ## Quick Install
 
-```bash
-# Local development:
-claude --plugin-dir /path/to/cc-websearch
+Clone the repository and point Claude Code at it:
 
-# From GitHub release (requires packaged .zip):
-claude --plugin-url https://github.com/your-org/cc-websearch/releases/download/v1.0/plugin.zip
+```bash
+git clone https://github.com/Djarvur/cc-websearch.git
+claude --plugin-dir /path/to/cc-websearch
 ```
 
-Compiled scripts are shipped in git (built via esbuild), so the plugin works immediately after install -- no build step is needed.
+Compiled scripts are shipped in git (built via esbuild), so the plugin works immediately after clone -- no build step is needed.
+
+`claude --plugin-url <url>` can load a packaged plugin `.zip` for a single session, but this repository does not currently publish one as a release asset.
 
 ## Usage
 
@@ -131,15 +132,15 @@ Precedence (highest to lowest):
 
 ### WebFetch
 
-| Feature             | Built-in WebFetch | cc-websearch WebFetch                               |
-| ------------------- | ----------------- | --------------------------------------------------- |
-| Content source      | Claude internal   | Fetch + Readability extraction                      |
-| API key required    | No                | No                                                  |
-| `url`               | Supported         | Supported                                           |
-| `prompt`            | Supported         | Supported                                           |
-| Output format       | Markdown text     | Markdown text                                       |
-| Redirect handling   | Follows redirects | HTTP-to-HTTPS upgrade, reports cross-host redirects |
-| Content type filter | HTML only         | HTML only (`text/html`, `application/xhtml`)        |
+| Feature             | Built-in WebFetch | cc-websearch WebFetch                                                                                                    |
+| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Content source      | Claude internal   | Fetch + Readability extraction                                                                                           |
+| API key required    | No                | No                                                                                                                       |
+| `url`               | Supported         | Supported                                                                                                                |
+| `prompt`            | Supported         | Supported                                                                                                                |
+| Output format       | Markdown text     | Markdown text                                                                                                            |
+| Redirect handling   | Follows redirects | HTTP-to-HTTPS upgrade; follows same-host redirects (max 10 hops); reports cross-host redirects instead of following them |
+| Content type filter | HTML only         | HTML only (`text/html`, `application/xhtml`)                                                                             |
 
 ## Architecture
 
@@ -148,10 +149,10 @@ cc-websearch uses DuckDuckGo as its sole search provider. There is no API key de
 ### WebSearch pipeline
 
 ```
-JSON input -> duck-duck-scrape (DDG Lite scraping) -> XML output with title, url, snippet
+JSON input -> fetch lite.duckduckgo.com -> cheerio parse -> XML output with title, url, snippet
 ```
 
-The websearch script sends a query to `lite.duckduckgo.com`, parses the HTML response, and formats results as `<search_results>` XML matching Claude Code's built-in output format. Citations are extracted from search result descriptions.
+The websearch script sends a query to `lite.duckduckgo.com`, parses the HTML response with cheerio, unwraps DuckDuckGo's `/l/?uddg=` redirect links to recover the real target URLs, and formats results as `<search_results>` XML matching Claude Code's built-in output format.
 
 ### WebFetch pipeline
 
@@ -165,7 +166,7 @@ WebFetch is a standalone content pipeline. It fetches the raw HTML, runs Mozilla
 
 - **No API keys** -- DuckDuckGo is free and requires no authentication
 - **No LLM in the pipeline** -- WebFetch extracts content, it does not analyze or summarize
-- **Plugin distribution** -- standard Claude Code plugin, installed via `claude plugin add`
+- **Plugin distribution** -- standard Claude Code plugin, loaded via `claude --plugin-dir`
 - **Scripts compiled to .cjs** -- esbuild bundles TypeScript into standalone Node.js executables
 
 ## Output Examples
@@ -205,7 +206,7 @@ are stripped during extraction.
 
 ### Prerequisites
 
-- Node.js 20 LTS or later
+- Node.js `^22.22.2 || ^24.15.0 || >=26.0.0` (see `engines` in `package.json`; CI runs on Node 24)
 - npm (ships with Node.js)
 
 ### Setup
@@ -216,12 +217,12 @@ npm install
 
 ### Commands
 
-| Command              | Description                               |
-| -------------------- | ----------------------------------------- |
-| `npm run build`      | Compile scripts with esbuild to `.cjs`    |
-| `npm test`           | Run vitest unit tests                     |
-| `npm run typecheck`  | TypeScript type checking (`tsc --noEmit`) |
-| `npm run lint`       | ESLint + Prettier formatting check        |
-| `npm run e2e`        | Build + run end-to-end tests              |
-| `npm run check`      | Run lint + typecheck + test + build       |
-| `npm run test:watch` | Run tests in watch mode                   |
+| Command              | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `npm run build`      | Compile scripts with esbuild to `.cjs`                          |
+| `npm test`           | Run vitest unit tests                                           |
+| `npm run typecheck`  | TypeScript type checking (`tsc --noEmit`)                       |
+| `npm run lint`       | ESLint + Prettier formatting check                              |
+| `npm run e2e`        | Build + run end-to-end tests (needs the `claude` CLI on `PATH`) |
+| `npm run check`      | Run lint + typecheck + test + build                             |
+| `npm run test:watch` | Run tests in watch mode                                         |


### PR DESCRIPTION
Documentation only — no source, config, dependency or workflow changes. 12 files, all Markdown.

## Why

The docs had drifted from the code, in three separate ways.

`CLAUDE.md` was generated from early planning material and described a **Perplexity-based architecture that was never shipped**. It listed the Perplexity SDK as a core dependency, pinned versions several majors behind (zod 3, jsdom 25, TypeScript 5), and claimed a Node 20 LTS runtime. Since it is the file loaded into context every session, everything wrong in it is wrong for every agent that reads it.

The `.planning/` docs never closed out **v1.2**. It shipped on 2026-05-24 and released as v1.2.4, but `ROADMAP.md` still showed 🚧 in progress, `STATE.md` sat at 67%, and `REQUIREMENTS.md` had HOOK-01..04 unchecked with traceability "Pending" — three months after Phase 10 completed.

The `research/` docs were written on 2026-05-22 as pre-implementation research, and several proposals **diverged from what was actually built**.

## What changed

### CLAUDE.md — 192 → 127 lines

Refreshed the content inside the GSD-managed blocks. **All `<!-- GSD:*-start/end -->` markers are byte-identical to `master`**, and the Project Skills / GSD Workflow Enforcement / Developer Profile blocks are restored verbatim, so `/gsd-*` regeneration still works unchanged.

- Perplexity stack removed; version table replaced with the actual pins from `package.json`.
- Runtime corrected to the real `engines` range `^22.22.2 || ^24.15.0 || >=26.0.0`; CI runs Node 24.
- Search backend corrected: DDG Lite is scraped with `fetch` + `cheerio`.
- Architecture and Conventions were placeholders ("not yet mapped") — filled in from the source, tests and CI config.
- Added Commands and Working agreements *outside* the GSD markers, where regeneration will not clobber them.

### README.md

- Prerequisites said "Node.js 20 LTS or later" — corrected to the actual `engines` range.
- The install example pointed at `github.com/**your-org**/cc-websearch/releases/.../plugin.zip` — a placeholder, and no release publishes a `.zip` asset. Replaced with the working `git clone` + `--plugin-dir` path.
- `claude plugin add` is not a subcommand.
- WebSearch pipeline corrected to `fetch` + `cheerio`; dropped the claim that citations are extracted from result descriptions, which the code does not do.
- Redirect handling described accurately: same-host only, max 10 hops, errors on cross-host.

### .planning/ — living docs

`PROJECT.md`, `STATE.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `MILESTONES.md` marked v1.2 shipped and progress 100%. The two open blockers are recorded as closed by the e2e suites that closed them. The four Phase 06 items deferred "requires push to GitHub" are resolved — CI, the weekly cron and Dependabot all run. `MILESTONES.md` logged only v1.0; added v1.1 and v1.2.

### .planning/research/ — as-built reconciliation

`STACK.md`, `ARCHITECTURE.md`, `SUMMARY.md`, `FEATURES.md`, `PITFALLS.md` now match what shipped:

- The hook is a fixed inline `echo` in `hooks/hooks.json`, not a `hooks/intercept-web-tools.sh` script parsing stdin with `jq`.
- Two separate matchers, not the `"WebSearch|WebFetch"` alternation.
- `.claude-plugin/plugin.json` was never given a `hooks` field. Added to "Stack NOT to Add" so it does not get reintroduced — see `f99c9d2`.
- Manifest examples showed version `0.2.0`; it is `1.2.4`.

**Historical records are untouched:** `milestones/1.0-*`, `v1.0-AUDIT.md` and everything under `phases/` are dated accounts of what happened, and their Perplexity references are correct as history.

## Verification

- `npm run lint` passes (`.planning/` is in `.prettierignore`, so it is not linted; `CLAUDE.md` and `README.md` are Prettier-clean).
- GSD markers diffed against `master`: identical.
- The as-built `hooks/hooks.json` example in `ARCHITECTURE.md` was verified to parse equal to the real file, not just eyeballed.
- No source, test, workflow, `package.json` or lockfile changes, so CI behaviour is unaffected.