### PR TITLE
ci: add the HOL Guard plugin scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # jsdom 30 requires ^22.22.2 || ^24.15.0 || >=26.0.0 (node 20 is EOL
           # and breaks with `webidl.util.markAsUncloneable is not a function`).

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,8 +9,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # jsdom 30 requires ^22.22.2 || ^24.15.0 || >=26.0.0 (node 20 is EOL
           # and breaks with `webidl.util.markAsUncloneable is not a function`).

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 

--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -1,0 +1,41 @@
+# HOL Guard plugin scanner (https://github.com/hashgraph-online/hol-guard).
+#
+# Scores the repository as a Claude Code plugin: manifest shape, skill/hook parseability,
+# secret and dangerous-command patterns, and GitHub Actions supply-chain hygiene. The gate
+# is score >= 80/100 with no high or critical findings, which is also what the
+# awesome-ai-plugins listing re-checks. The repository currently scores 100/100.
+#
+# Scanner behaviour is configured by .plugin-scanner.toml at the repository root, which the
+# action picks up automatically.
+#
+# The action is pinned to an immutable commit SHA so a moved tag cannot change the code this
+# workflow executes. It needs no secrets and only contents: read.
+name: Plugin Security Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: HOL Guard plugin scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@7e420247177d5beebbd3747ed16e4b29a1e41f57 # v1.2.551
+        with:
+          plugin_dir: '.'
+          min_score: 80
+          fail_on_severity: high

--- a/.plugin-scanner.toml
+++ b/.plugin-scanner.toml
@@ -1,0 +1,20 @@
+# Configuration for the HOL Guard plugin scanner (https://github.com/hashgraph-online/hol-guard),
+# run by .github/workflows/plugin-scan.yml.
+
+[scanner]
+profile = "default"
+
+# The committed esbuild bundles are generated artifacts, not hand-written source: they inline every
+# runtime dependency, so the scanner's source-level rules report findings that belong to vendored
+# libraries rather than to this project.
+#
+# Concretely, DANGEROUS_DYNAMIC_EXECUTION fires on jsdom code inlined into webfetch.cjs:
+#   * `globalObject.eval("(async function* () {})")` -- webidl-conversions grabbing the
+#     AsyncGenerator prototype (x3),
+#   * `window.eval(scriptSource)` -- jsdom's script runner, which is unreachable here because
+#     src/lib/content.ts constructs `new JSDOM(html, { url })` without `runScripts`, leaving
+#     script execution disabled.
+#
+# The sources these bundles are built from (src/, build.ts) are still scanned normally, so a real
+# `eval` added to this project's own code would still be reported.
+ignore_paths = ["skills/*/scripts/*.cjs", "scripts/*.cjs"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Neither ends up in the bundles. They only generate Dependabot noise and should b
 | `build.ts`              | esbuild bundling into `skills/*/scripts/*.cjs`                       |
 | `skills/*/SKILL.md`     | Skill definitions that shell out to the bundles                      |
 | `hooks/hooks.json`      | `PreToolUse` hooks denying the built-in WebSearch/WebFetch tools     |
+| `.plugin-scanner.toml`  | HOL Guard scanner config — suppresses findings in generated bundles  |
 
 ### Pipelines
 
@@ -173,3 +174,6 @@ Do not make direct repo edits outside a GSD workflow unless the user explicitly 
   what users actually run.
 - Dependabot PRs that have sat open for a while are branched from a stale `master` and will fail
   lint on unrelated files. Rebase them before judging the failure.
+- `.github/workflows/plugin-scan.yml` runs the HOL Guard plugin scanner and gates on
+  score >= 80/100 with no high/critical findings (currently 100/100). Third-party GitHub Actions
+  must stay pinned to full commit SHAs, or that job fails.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of `cc-websearch` receives security fixes. The plugin ships
+compiled bundles in git, so "latest" means the current `master` tag/release — older tags are not
+patched.
+
+| Version        | Supported |
+| -------------- | --------- |
+| latest release | ✅        |
+| older releases | ❌        |
+
+## Reporting a Vulnerability
+
+Please report security issues privately through GitHub's private vulnerability reporting:
+
+<https://github.com/Djarvur/cc-websearch/security/advisories/new>
+
+Do not open a public issue for an unfixed vulnerability.
+
+Include, where possible:
+
+- the affected skill (`websearch` or `webfetch`) and plugin version,
+- the JSON stdin payload or URL that triggers the issue,
+- what happens versus what you expected,
+- Node.js version and operating system.
+
+You can expect an initial acknowledgement within 7 days and a status update within 30 days.
+
+## Scope
+
+This plugin runs locally as two Node scripts invoked by Claude Code. Reports are in scope when they
+concern:
+
+- **Command or code injection** — stdin payloads that lead to code execution, shell invocation, or
+  escape from the intended `fetch` → parse → stdout pipeline.
+- **SSRF and request forgery** — bypasses of the `allowed_domains` / `blocked_domains` filtering in
+  `src/lib/filter.ts`, or of the redirect and HTTPS-upgrade handling in `src/lib/fetch.ts`.
+- **Data exfiltration** — fetched page content or local files reaching an unintended destination.
+- **Supply chain** — a committed bundle in `skills/*/scripts/*.cjs` that does not correspond to the
+  sources in `src/` plus the pinned dependencies in `package-lock.json`.
+- **Configuration handling** — issues in `~/.config/websearch/config.json` or `WEBSEARCH_*`
+  environment variable parsing.
+
+Out of scope:
+
+- Vulnerabilities in DuckDuckGo itself or in the remote pages that WebFetch retrieves. Fetched
+  content is untrusted input by design; treat scraped results accordingly.
+- Denial of service caused by pointing the plugin at a hostile or extremely large page.
+- Findings that require an attacker to already control the local machine or the user's shell.
+
+## Hardening Notes
+
+- The scripts take JSON on stdin only. There is no flag parsing and no shell interpolation of user
+  input.
+- `jsdom` is instantiated without `runScripts`, so scripts inside fetched pages are never executed.
+- All external input is validated by a zod `strictObject` before use; unknown keys are rejected.
+- No API keys or credentials are used or stored by the plugin.

--- a/skills/webfetch/SKILL.md
+++ b/skills/webfetch/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: webfetch
 description: Replacement for built-in WebFetch — Fetch and summarize web page content. Use this skill when the user provides a URL and asks about its content.
 allowed-tools: Bash(node *)
 ---

--- a/skills/websearch/SKILL.md
+++ b/skills/websearch/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: websearch
 description: Replacement for built-in WebSearch — Search the web using DuckDuckGo. Use this skill when the user needs current information, web search results, or to find web pages about a topic.
 allowed-tools: Bash(node *)
 ---


### PR DESCRIPTION
# ci: add the HOL Guard plugin scanner

Adds the [HOL Guard](https://github.com/hashgraph-online/hol-guard) plugin scanner to CI and fixes everything it flagged. The repository went from **72/100 (C — Acceptable)** with 1 high / 5 medium / 3 low findings to **100/100 (A — Excellent)** with zero findings.

## What the scanner is

`hashgraph-online/ai-plugin-scanner-action` scores a repository as an AI-assistant plugin: manifest shape and semver, skill/hook parseability, secret and dangerous-command patterns, and GitHub Actions supply-chain hygiene. It is the same gate the `awesome-ai-plugins` listing re-checks (score ≥ 80 with no high or critical findings).

## Changes

### `.github/workflows/plugin-scan.yml` (new)

Runs on push to `master`, on pull requests, and on manual dispatch.

- Gate: `min_score: 80`, `fail_on_severity: high`.
- The action is pinned to an immutable commit SHA (`v1.2.551`) so a moved tag cannot change the code the workflow executes.
- `permissions: contents: read` only, `persist-credentials: false` on checkout, no secrets.
- `concurrency` matches the existing `ci.yml` convention.

Scanner behaviour comes from `.plugin-scanner.toml` at the repo root, which the action discovers automatically — no extra inputs needed.

### `.plugin-scanner.toml` (new) — suppressing one false positive

The scanner reported **1 high finding**, `DANGEROUS_DYNAMIC_EXECUTION`, on `skills/webfetch/scripts/webfetch.cjs`. It is a false positive on vendored code.

The committed esbuild bundles inline every runtime dependency, so source-level rules see library code as if it were ours. All four `eval` hits belong to jsdom:

- `globalObject.eval("(async function* () {})")` ×3 — `webidl-conversions` grabbing the `AsyncGenerator` prototype;
- `window.eval(scriptSource)` ×1 — jsdom's script runner, which is **unreachable here**: `src/lib/content.ts` constructs `new JSDOM(html, { url })` without `runScripts`, so script execution stays disabled.

The project's own code contains no `eval` or `new Function`.

The fix is a path-scoped `ignore_paths` for generated bundles (`skills/*/scripts/*.cjs`, `scripts/*.cjs`) rather than disabling the rule repo-wide. `src/` and `build.ts` are still scanned, so a real `eval` added to this project's own code would still be reported.

### `ci.yml`, `cron.yml`, `dependabot-auto-merge.yml` — pin actions to SHAs

The scanner's **5 medium findings** were all `GITHUB_ACTION_UNPINNED`. This one is real: a floating tag can be moved to point at different code, so a tag-referenced action is not a reproducible dependency.

| Action                     | Was  | Now                                          |
| -------------------------- | ---- | -------------------------------------------- |
| `actions/checkout`         | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1) |
| `actions/setup-node`       | `v7` | `820762786026740c76f36085b0efc47a31fe5020` (v7.0.0) |
| `dependabot/fetch-metadata`| `v3` | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (v3.1.0) |

The version stays in a trailing comment. Dependabot's `github-actions` ecosystem — already configured in `.github/dependabot.yml` — understands SHA pins and keeps bumping them, so this costs nothing in maintenance.

### `skills/*/SKILL.md` — add `name` frontmatter

**2 low findings**, `CLAUDE_SKILL_FRONTMATTER_INVALID`. Both skills carried `description` and `allowed-tools` but no `name`, which the Claude skill spec requires. Added `name: websearch` and `name: webfetch`.

### `SECURITY.md` (new)

**1 low finding**, `SECURITY_MD_MISSING`. Reporting goes through GitHub private vulnerability reporting (no email address published). The file states an explicit scope for a plugin whose inputs are untrusted URLs and scraped pages: SSRF and `allowed_domains` / `blocked_domains` bypasses, injection through the stdin payload, a committed bundle that does not match `src/`, and config / `WEBSEARCH_*` parsing. Vulnerabilities in DuckDuckGo itself and in fetched pages are out of scope.

### `CLAUDE.md`

Records the new CI gate and the requirement that third-party actions stay SHA-pinned, plus a row for `.plugin-scanner.toml` in the architecture table.

## Verification

- `plugin-scanner scan . --min-score 80 --fail-on-severity high` → **100/100 (A)**, `critical:0, high:0, medium:0, low:0, info:0`, exit 0.
- `npm run lint`, `npm run typecheck` — clean.
- `npm test` — 143 passed, 14 files.
- `npm run build` — bundles regenerate byte-identical (no `src/` change in this PR).

## Notes / follow-ups

- The gate is 80 while the repo scores 100, leaving headroom for rules added in future scanner versions. Raise it to 90 if you would rather catch drift earlier.
- PR comments from the scanner are effectively off: the action would need `pull-requests: write` and `GITHUB_TOKEN` passed into its environment. Left disabled to keep the workflow's permissions minimal.
